### PR TITLE
Fix a number of small typos

### DIFF
--- a/src/content/_index.md
+++ b/src/content/_index.md
@@ -20,4 +20,4 @@ curl -X GET "https://api.cloudflare.com/client/v4/zones/cd7d0123e3012345da9420df
 -H "Authorization: Bearer YQSn-xWAQiiEh9qM58wZNnyQS7FUdoqGIUAbrh7T"
 ```
 
-For spcificing guidance on making API calls, see our [API schema docs](https://api.cloudflare.com) or the appropriate [Developer Docs section](https://developers.cloudflare.com) for that service. Additionally, if you are using [golang](https://github.com/cloudflare/cloudflare-go) or [Hashicorp's Terraform](https://github.com/terraform-providers/terraform-provider-cloudflare) you can leverage our 1st party libraries to integrate with Cloudflare's API.
+For specifying guidance on making API calls, see our [API schema docs](https://api.cloudflare.com) or the appropriate [Developer Docs section](https://developers.cloudflare.com) for that service. Additionally, if you are using [golang](https://github.com/cloudflare/cloudflare-go) or [Hashicorp's Terraform](https://github.com/terraform-providers/terraform-provider-cloudflare) you can leverage our 1st party libraries to integrate with Cloudflare's API.

--- a/src/content/about/tips/debugging.md
+++ b/src/content/about/tips/debugging.md
@@ -68,7 +68,7 @@ A common quick hack to get some debug information out of your Worker is to retur
 
 A Worker can make HTTP requests to any site on the public internet. Many projects already have a service like [Sentry](https://sentry.io/) set up to collect error logs from browser-side JavaScript. You can use the same service to collect errors from your Worker, by making an HTTP request to the service to report the error. Refer to your service's API documentation for details on what kind of request to make.
 
-When logging using this strategy, you must account for the fact that outstanding asynchronous tasks are canceled as soon as a Worker finishes sending its main response body to the client. In order to ensure that a logging subrequest completes, you can pass its `fetch()` promise to [`event.waitUntil()`](https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent/waitUntil). For example:
+When logging using this strategy, you must account for the fact that outstanding asynchronous tasks are cancelled as soon as a Worker finishes sending its main response body to the client. In order to ensure that a logging subrequest completes, you can pass its `fetch()` promise to [`event.waitUntil()`](https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent/waitUntil). For example:
 
 ```javascript
    ...

--- a/src/content/keys/_index.html
+++ b/src/content/keys/_index.html
@@ -1066,7 +1066,7 @@ body .markdown-body
 <p>Full permissions - Similar to (1), API Keys have the exact same permissions as the user which means if the user can delete zones, or change DNS records so can the key.</p>
 </li>
 <li>
-<p>Limited to 1 per user - Only one API Key can be provisioned per user. This complicates using Cloudflare&rsquo;s API in production systems where maintaing two secrets for accessing the API is important in the case 1 needs to be rolled.</p>
+<p>Limited to 1 per user - Only one API Key can be provisioned per user. This complicates using Cloudflare&rsquo;s API in production systems where maintaining two secrets for accessing the API is important in the case 1 needs to be rolled.</p>
 </li>
 <li>
 <p>Lack of advanced limits on usage - API Tokens can be limited to use in specific time windows and expire or be limited to use from specific IP ranges.</p>

--- a/src/content/keys/_index.md
+++ b/src/content/keys/_index.md
@@ -12,7 +12,7 @@ API Keys have multiple limitations when compared to API Tokens:
 
 2. **Full permissions** - Similar to (1), API Keys have the exact same permissions as the user which means if the user can delete zones, or change DNS records so can the key.
 
-3. **Limited to 1 per user** - Only one API Key can be provisioned per user. This complicates using Cloudflare's API in production systems where maintaing two secrets for accessing the API is important in the case 1 needs to be rolled.
+3. **Limited to 1 per user** - Only one API Key can be provisioned per user. This complicates using Cloudflare's API in production systems where maintaining two secrets for accessing the API is important in the case 1 needs to be rolled.
 
 4. **Lack of advanced limits on usage** - API Tokens can be limited to use in specific time windows and expire or be limited to use from specific IP ranges.
 

--- a/src/content/quick/_index.md
+++ b/src/content/quick/_index.md
@@ -20,4 +20,4 @@ curl -X GET "https://api.cloudflare.com/client/v4/zones/cd7d0123e3012345da9420df
 -H "Authorization: Bearer YQSn-xWAQiiEh9qM58wZNnyQS7FUdoqGIUAbrh7T"
 ```
 
-For spcificing guidance on making API calls, see our [API schema docs](https://api.cloudflare.com) or the appropriate [Developer Docs section](https://developers.cloudflare.com) for that service. Additionally, if you are using [golang](https://github.com/cloudflare/cloudflare-go) or [Hashicorp's Terraform](https://github.com/terraform-providers/terraform-provider-cloudflare) you can leverage our 1st party libraries to integrate with Cloudflare's API.
+For specifying guidance on making API calls, see our [API schema docs](https://api.cloudflare.com) or the appropriate [Developer Docs section](https://developers.cloudflare.com) for that service. Additionally, if you are using [golang](https://github.com/cloudflare/cloudflare-go) or [Hashicorp's Terraform](https://github.com/terraform-providers/terraform-provider-cloudflare) you can leverage our 1st party libraries to integrate with Cloudflare's API.

--- a/src/content/tokens/advanced/api.md
+++ b/src/content/tokens/advanced/api.md
@@ -20,7 +20,7 @@ Once an API Token is created that can create other tokens, the next step is usin
 Creating a Token requires defining two sections of config and then sending the API request.
 
 1. Define the policy
-2. Define the restirctions
+2. Define the restrictions
 3. Create the token
 
 ### Define the Policy


### PR DESCRIPTION
These were found in reading the documents, and via `hunspell`, and only represent unambiguous
changes -- hyphenation in words like 'walkthrough' or 'subrequest' have been left out.

Fixes: #34